### PR TITLE
Updating runnable command to add passenger repository to apt sources.list

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -249,7 +249,7 @@ sudo apt-get install python-software-properties -y
 sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo add-apt-repository ppa:couchdb/stable
 
-echo "deb https://oss-binaries.phusionpassenger.com/apt/passenger trusty main" >> sudo /etc/apt/sources.list
+echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger trusty main' | sudo tee --append /etc/apt/sources.list > /dev/null
 ```
 
 #### Update package lists


### PR DESCRIPTION
This update is because shell redirects don't know about "sudo" and interpret it as the redirected filename.  If the command is run as-is it will create a file named sudo in the current working directory.

The updated command in the PR will act as expected reducing any surprises when they find they can't install passenger later.