### PR TITLE
Ensure NodeJS 0.12.x and corresponding NPM command install during automatic installation.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,4 +499,4 @@ DEPENDENCIES
   will_paginate-bootstrap (~> 1.0.1)
 
 BUNDLED WITH
-   1.10.3
+   1.10.4

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,12 @@ Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "chef/ubuntu-14.04"
 
+  # Ensure that we get NodeJS 0.12.x
+  config.vm.provision "shell", inline: "
+    sudo apt-get install curl -y
+    curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
+    sudo apt-get install nodejs -y
+  "
   # Enable provisioning with chef solo
   config.vm.provision :chef_solo do |chef|
     chef.json = { "dotenv" => ENV["DOTENV"], "application" => ENV["APPLICATION"] }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 20150617085746) do
 
   create_table "alerts", force: :cascade do |t|
     t.integer  "source_id",    limit: 4
-    t.string   "class_name",   limit: 191
+    t.string   "class_name",   limit: 255
     t.text     "message",      limit: 16777215
     t.text     "trace",        limit: 65535
     t.string   "target_url",   limit: 1000
@@ -104,7 +104,7 @@ ActiveRecord::Schema.define(version: 20150617085746) do
 
   create_table "filters", force: :cascade do |t|
     t.string   "type",        limit: 255,                  null: false
-    t.string   "name",        limit: 255,                  null: false
+    t.string   "name",        limit: 191,                  null: false
     t.string   "title",       limit: 255,                  null: false
     t.text     "description", limit: 65535
     t.boolean  "active",      limit: 1,     default: true
@@ -234,7 +234,7 @@ ActiveRecord::Schema.define(version: 20150617085746) do
   add_index "retrieval_statuses", ["work_id"], name: "index_retrieval_statuses_on_work_id", using: :btree
 
   create_table "reviews", force: :cascade do |t|
-    t.string   "name",       limit: 191
+    t.string   "name",       limit: 255
     t.integer  "state_id",   limit: 4
     t.text     "message",    limit: 65535
     t.integer  "input",      limit: 4
@@ -292,7 +292,7 @@ ActiveRecord::Schema.define(version: 20150617085746) do
   add_index "status", ["created_at"], name: "index_status_created_at", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 191, default: ""
+    t.string   "email",                  limit: 255, default: ""
     t.string   "encrypted_password",     limit: 255, default: "",     null: false
     t.string   "reset_password_token",   limit: 191
     t.datetime "reset_password_sent_at"
@@ -326,11 +326,11 @@ ActiveRecord::Schema.define(version: 20150617085746) do
   end
 
   create_table "works", force: :cascade do |t|
-    t.string   "doi",           limit: 191
+    t.string   "doi",           limit: 255
     t.text     "title",         limit: 65535
     t.date     "published_on"
-    t.string   "pmid",          limit: 191
-    t.string   "pmcid",         limit: 191
+    t.string   "pmid",          limit: 255
+    t.string   "pmcid",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "canonical_url", limit: 65535
@@ -339,15 +339,15 @@ ActiveRecord::Schema.define(version: 20150617085746) do
     t.integer  "month",         limit: 4
     t.integer  "day",           limit: 4
     t.integer  "publisher_id",  limit: 4
+    t.string   "pid_type",      limit: 255,   default: "url", null: false
     t.text     "pid",           limit: 65535,                 null: false
     t.text     "csl",           limit: 65535
     t.integer  "work_type_id",  limit: 4
     t.boolean  "tracked",       limit: 1,     default: false
-    t.string   "scp",           limit: 191
-    t.string   "wos",           limit: 191
-    t.string   "ark",           limit: 191
-    t.string   "arxiv",         limit: 191
-    t.string   "pid_type",      limit: 255,   default: "url"
+    t.string   "scp",           limit: 255
+    t.string   "wos",           limit: 255
+    t.string   "ark",           limit: 255
+    t.string   "arxiv",         limit: 255
   end
 
   add_index "works", ["ark", "published_on", "id"], name: "index_works_on_ark_published_on_id", using: :btree


### PR DESCRIPTION
I see that in lagotto-cookbook's [attributes/default.rb](https://github.com/articlemetrics/lagotto-cookbook/blob/master/attributes/default.rb) the intended for NodeJS 0.12.0 and NPM 2.7.5 but those attributes didn't seem to have any effect. 

NodeJS 0.10.25 was being installed (forcing an apt-get upgrade would cause 0.10.38 to be installed), but NPM didn't install at all. This would cause phantomjs installation to fail as well.

This works and installs NodeJS the latest stable 0.12.x release along with NPM and allows the rest of the automatic installation to complete successfully.

I'm not sure if this is the correct way to resolve this, but wanted to raise the issue and share the change in case there's a better way to go about this.