### PR TITLE
Updates to CSV parsing specs

### DIFF
--- a/spec/models/reports/alm_stats_report_spec.rb
+++ b/spec/models/reports/alm_stats_report_spec.rb
@@ -163,8 +163,8 @@ describe AlmStatsReport do
   describe "#to_csv" do
     let(:expected_csv){ <<-CSV.gsub(/^\s+/, '')
       pid,publication_date,title,mendeley,pmc,counter
-      #{mendeley_work.pid},2014-07-01,Defrosting the Digital Library: Bibliographic Tools for the Next Generation Web,3,0,0
-      #{pmc_work.pid},2014-07-01,Defrosting the Digital Library: Bibliographic Tools for the Next Generation Web,0,1420,0
+      #{mendeley_work.pid},#{mendeley_work.published_on.to_date},#{mendeley_work.title},3,0,0
+      #{pmc_work.pid},#{pmc_work.published_on.to_date},#{pmc_work.title},0,1420,0
       CSV
     }
 

--- a/spec/support/shared_examples/source_by_month_report_shared_examples.rb
+++ b/spec/support/shared_examples/source_by_month_report_shared_examples.rb
@@ -1,4 +1,4 @@
-gitxshared_examples_for "SourceByMonthReport examples" do |options|
+shared_examples_for "SourceByMonthReport examples" do |options|
   raise ArgumentError("Missing :source_factory") unless options[:source_factory]
   raise ArgumentError("Missing :report_class") unless options[:report_class]
 


### PR DESCRIPTION
This does the following to fix the specs for CSV parsing:

* Removing erroneous "gitx" reference.
* Removing hard-coded values in a spec for values not explicitly defined in the spec. In particular, the publication date was based on today's date which was causing `alm_stats_report_spec.rb` to fail.

I changed the date on my computer to a few weeks in the future to make sure no other report specs would fail for similar reasons.

