### PR TITLE
Fixes issue with migration 20150708003940_change_to_utf8mb_encoding

### DIFF
--- a/db/migrate/20150708003940_change_to_utf8mb_encoding.rb
+++ b/db/migrate/20150708003940_change_to_utf8mb_encoding.rb
@@ -1,33 +1,33 @@
 class ChangeToUtf8mbEncoding < ActiveRecord::Migration
-  UTF8_TEXT_PAIRS = {
-    'works'  => 'title',
-    'alerts' => 'trace'
-  }
+  UTF8_TEXT_PAIRS = [
+    'works' , 'title',
+    'alerts', 'trace'
+  ]
 
-  UTF8_MEDIUMTEXT_PAIRS = {
-    'alerts' => 'message',
-    'alerts' => 'details',
-    'retrieval_statuses' => 'extra'
-  }
+  UTF8_MEDIUMTEXT_PAIRS = [
+    'alerts', 'message',
+    'alerts', 'details',
+    'retrieval_statuses', 'extra'
+  ]
 
-  UTF8_INDEX_PAIRS = {
-    'alerts' => 'class_name',
-    'api_requests' => 'api_key',
-    'data_migrations' => 'version',
-    'reviews' => 'name',
-    'sources' => 'type',
-    'sources' => 'name',
-    'users' => 'email',
-    'users' => 'reset_password_token',
-    'users' => 'authentication_token',
-    'works' => 'doi',
-    'works' => 'pmid',
-    'works' => 'pmcid',
-    'works' => 'wos',
-    'works' => 'scp',
-    'works' => 'ark',
-    'works' => 'arxiv'
-  }
+  UTF8_INDEX_PAIRS = [
+    'alerts', 'class_name',
+    'api_requests', 'api_key',
+    'data_migrations', 'version',
+    'reviews', 'name',
+    'sources', 'type',
+    'sources', 'name',
+    'users', 'email',
+    'users', 'reset_password_token',
+    'users', 'authentication_token',
+    'works', 'doi',
+    'works', 'pmid',
+    'works', 'pmcid',
+    'works', 'wos',
+    'works', 'scp',
+    'works', 'ark',
+    'works', 'arxiv'
+  ]
 
   def self.up
     # execute "ALTER DATABASE `#{ActiveRecord::Base.connection.current_database}` CHARACTER SET utf8mb4;"
@@ -36,15 +36,15 @@ class ChangeToUtf8mbEncoding < ActiveRecord::Migration
     #   execute "ALTER TABLE `#{table}` CHARACTER SET = utf8mb4;"
     # end
 
-    UTF8_TEXT_PAIRS.each do |table, col|
+    UTF8_TEXT_PAIRS.each_slice(2) do |table, col|
       execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
     end
 
-    UTF8_MEDIUMTEXT_PAIRS.each do |table, col|
+    UTF8_MEDIUMTEXT_PAIRS.each_slice(2) do |table, col|
       execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
     end
 
-    UTF8_INDEX_PAIRS.each do |table, col|
+    UTF8_INDEX_PAIRS.each_slice(2) do |table, col|
       execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
     end
 
@@ -59,15 +59,15 @@ class ChangeToUtf8mbEncoding < ActiveRecord::Migration
     #   execute "ALTER TABLE `#{table}` CHARACTER SET = utf8;"
     # end
 
-    UTF8_TEXT_PAIRS.each do |table, col|
+    UTF8_TEXT_PAIRS.each_slice(2) do |table, col|
       execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci;;"
     end
 
-    UTF8_MEDIUMTEXT_PAIRS.each do |table, col|
+    UTF8_MEDIUMTEXT_PAIRS.each_slice(2) do |table, col|
       execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` MEDIUMTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci;;"
     end
 
-    UTF8_INDEX_PAIRS.each do |table, col|
+    UTF8_INDEX_PAIRS.each_slice(2) do |table, col|
       execute "ALTER TABLE `#{table}` CHANGE `#{col}` `#{col}` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -249,7 +249,7 @@ ActiveRecord::Schema.define(version: 20150708003940) do
   add_index "reviews", ["state_id"], name: "index_reviews_on_state_id", using: :btree
 
   create_table "sources", force: :cascade do |t|
-    t.string   "type",        limit: 191,                                   null: false
+    t.string   "type",        limit: 191
     t.string   "name",        limit: 191
     t.string   "title",       limit: 255,                                   null: false
     t.datetime "run_at",                    default: '1970-01-01 00:00:00', null: false
@@ -292,7 +292,7 @@ ActiveRecord::Schema.define(version: 20150708003940) do
   add_index "status", ["created_at"], name: "index_status_created_at", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: ""
+    t.string   "email",                  limit: 191
     t.string   "encrypted_password",     limit: 255, default: "",     null: false
     t.string   "reset_password_token",   limit: 191
     t.datetime "reset_password_sent_at"
@@ -326,11 +326,11 @@ ActiveRecord::Schema.define(version: 20150708003940) do
   end
 
   create_table "works", force: :cascade do |t|
-    t.string   "doi",           limit: 255
+    t.string   "doi",           limit: 191
     t.text     "title",         limit: 65535
     t.date     "published_on"
-    t.string   "pmid",          limit: 255
-    t.string   "pmcid",         limit: 255
+    t.string   "pmid",          limit: 191
+    t.string   "pmcid",         limit: 191
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "canonical_url", limit: 65535
@@ -344,9 +344,9 @@ ActiveRecord::Schema.define(version: 20150708003940) do
     t.text     "csl",           limit: 65535
     t.integer  "work_type_id",  limit: 4
     t.boolean  "tracked",                     default: false
-    t.string   "scp",           limit: 255
-    t.string   "wos",           limit: 255
-    t.string   "ark",           limit: 255
+    t.string   "scp",           limit: 191
+    t.string   "wos",           limit: 191
+    t.string   "ark",           limit: 191
     t.string   "arxiv",         limit: 191
   end
 


### PR DESCRIPTION
This ensures that all of the intended table/column pairs get updated to utf8mb4.

This also fixes an issue for me where running `rake db:test:prepare` was failing due to an index key length being too long.

Since this modifies an existing migration you will want to run:

```
bin/rake db:rollback STEP=1
bin/rake db:migrate
```

OR.... we could also add this as a new migration so you can just go up.