### PR TITLE
Issues/343 updating event and reference sort order

### DIFF
--- a/app/controllers/api/v6/events_controller.rb
+++ b/app/controllers/api/v6/events_controller.rb
@@ -32,8 +32,11 @@ class Api::V6::EventsController < Api::BaseController
     end
 
     collection = collection.joins(:source).where("private <= ?", is_admin_or_staff?)
-
-    if params[:sort]
+    if params[:sort] == "created_at"
+      # use :id for sort order because it is already indexed and it will achieve the same outcome
+      # as the :created_at column since both are intended to go up sequentially
+      collection = collection.order("retrieval_statuses.id ASC")
+    elsif params[:sort]
       sort = ["pdf", "html", "readers", "comments", "likes", "total"].include?(params[:sort]) ? params[:sort] : "total"
       collection = collection.order(sort.to_sym => :desc)
     else

--- a/app/controllers/api/v6/references_controller.rb
+++ b/app/controllers/api/v6/references_controller.rb
@@ -44,7 +44,13 @@ class Api::V6::ReferencesController < Api::BaseController
       collection = collection.where(source_id: source.id)
     end
 
-    collection = collection.includes(:related_work).order("works.published_on DESC")
+    collection = collection.includes(:related_work)
+
+    if params[:sort] == "created_at"
+      collection = collection.order("works.created_at ASC")
+    else
+      collection = collection.order("works.published_on DESC")
+    end
 
     per_page = params[:per_page] && (0..1000).include?(params[:per_page].to_i) ? params[:per_page].to_i : 1000
 

--- a/lib/api_crawler.rb
+++ b/lib/api_crawler.rb
@@ -26,7 +26,7 @@ class ApiCrawler
 
     next_uri = URI.parse(@url)
 
-    next_uri.query = {page: @start_page}.to_query if @start_page
+    next_uri.query = query_params_with_page(next_uri.query, @start_page)
 
     while next_uri do
       benchmark(next_uri) do
@@ -81,11 +81,18 @@ class ApiCrawler
 
     if continue_crawling?
       next_uri = URI.parse(@url)
-      next_uri.query = {page: @pageno+1}.to_query
+      next_uri.query = query_params_with_page(next_uri.query, @pageno+1)
       next_uri
     else
       nil
     end
+  end
+
+  def query_params_with_page(query, page)
+    return query unless page
+    params = Rack::Utils.parse_nested_query(query).with_indifferent_access
+    params[:page] = page
+    params.to_query
   end
 
   def continue_crawling?

--- a/lib/api_crawler.rb
+++ b/lib/api_crawler.rb
@@ -67,15 +67,15 @@ class ApiCrawler
 
   def process_response_body_and_get_next_page_uri(request_uri, response_body)
     begin
-      json = JSON.parse(response_body)
+      json_data = JSON.parse(response_body)
     rescue JSON::ParserError
       raise(MalformedResponseError, "Response body was not valid JSON in:\n #{response_body}")
     end
 
-    @output.puts response_body
+    @output.puts response_body.gsub("\n", "")
     @num_pages_processed += 1
 
-    meta = json["meta"] || raise(MalformedResponseError, "Missing meta element in:\n #{response_body}")
+    meta = json_data["meta"] || raise(MalformedResponseError, "Missing meta element in:\n #{response_body}")
     @pageno = meta["page"] || raise(MalformedResponseError, "Missing page property in the meta element in:\n #{response_body}")
     @total_pages = meta["total_pages"] || raise(MalformedResponseError, "Missing total_pages property in the meta element in:\n #{response_body}")
 

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -8,22 +8,22 @@ namespace :api do
 
     desc 'Takes a snapshot of the events API, zips it, and uploads to Zenodo'
     task :events => [:environment, :requirements_check] do
-      endpoint = "/api/references"
-      ApiSnapshotUtility.snapshot_later "/api/events", upload_on_finished: true
-      puts "Queuing a snapshot for /api/events"
+      endpoint = "/api/events"
+      ApiSnapshotUtility.snapshot_later "#{endpoint}?sort=created_at", upload_on_finished: true
+      puts "Queuing a snapshot for #{endpoint}"
     end
 
     desc 'Takes a snapshot of the references API, zips it, and uploads to Zenodo'
     task :references => [:environment, :requirements_check] do
       endpoint = "/api/references"
-      ApiSnapshotUtility.snapshot_later endpoint, upload_on_finished: true
+      ApiSnapshotUtility.snapshot_later "#{endpoint}?sort=created_at", upload_on_finished: true
       puts "Queuing a snapshot for #{endpoint}"
     end
 
     desc 'Takes a snapshot of the works API, zips it, and uploads to Zenodo'
     task :works => [:environment, :requirements_check] do
       endpoint = "/api/works"
-      ApiSnapshotUtility.snapshot_later endpoint, upload_on_finished: true
+      ApiSnapshotUtility.snapshot_later "#{endpoint}?sort=created_at", upload_on_finished: true
       puts "Queuing a snapshot for #{endpoint}"
     end
 

--- a/spec/apis/v6/events_spec.rb
+++ b/spec/apis/v6/events_spec.rb
@@ -53,6 +53,21 @@ describe "/api/v6/events", :type => :api do
         expect(item["by_month"]).not_to be_nil
         expect(item["by_year"]).not_to be_nil
       end
+
+      it "can be sorted by retrieval_statuses.id using the created_at query parameter" do
+        get "/api/events?sort=created_at", nil, headers
+        response = JSON.parse(last_response.body)
+        data = response["events"]
+        actual_work_ids = data.map{ |work| work["work_id"] }
+
+        expected_work_ids = RetrievalStatus.all
+          .includes(:work)
+          .order("retrieval_statuses.id ASC")
+          .map(&:work)
+          .map(&:pid)
+
+        expect(actual_work_ids).to eq(expected_work_ids)
+      end
     end
 
     context "show" do

--- a/spec/apis/v6/references_spec.rb
+++ b/spec/apis/v6/references_spec.rb
@@ -41,6 +41,20 @@ describe "/api/v6/references", :type => :api do
         expect(item["title"]).to eq("Defrosting the Digital Library: Bibliographic Tools for the Next Generation Web")
         expect(item["events"]).to eq({})
       end
+
+      it "can be sorted by works.created_at using the created_at query parameter" do
+        get "#{uri}?sort=created_at", nil, headers
+        response = JSON.parse(last_response.body)
+        data = response["references"]
+        actual_work_dois = data.map{ |work| work["DOI"] }
+
+        expected_work_dois = Relation.referencable.includes(:related_work)
+          .order("works.created_at ASC")
+          .map(&:related_work)
+          .map(&:doi)
+
+        expect(actual_work_dois).to eq(expected_work_dois)
+      end
     end
 
     context "show work_id" do

--- a/spec/apis/v6/works_spec.rb
+++ b/spec/apis/v6/works_spec.rb
@@ -161,7 +161,7 @@ describe "/api/v6/works", :type => :api do
         end).to be true
       end
 
-      it "can be sorted by created_at" do
+      it "can be sorted by works.created_at using the created_at query parameter" do
         get "/api/works?sort=created_at", nil, headers
         response = JSON.parse(last_response.body)
         data = response["works"]

--- a/spec/lib/api_crawler_spec.rb
+++ b/spec/lib/api_crawler_spec.rb
@@ -140,7 +140,17 @@ describe ApiCrawler do
     end
 
     context "and the responses include newlines" do
-      it "removes the newlines when writing to :output" do
+      let(:page_1_response){ build_response_with_body(total_pages:1, page: 1) }
+
+      before do
+        page_1_response[:body] = "{\"meta\":{\"total_pages\":1, \"page\":1}, \"a\":5\n,\"b\":5}\n"
+        stub_request(:get, "www.example.com").to_return page_1_response
+      end
+
+      it "removes the newlines when writing to :output so that every response is written as a single line" do
+        api_crawler.crawl
+        output.rewind
+        expect(output.read).to eq("#{page_1_response[:body].gsub("\n", "")}\n")
       end
     end
 

--- a/spec/lib/api_crawler_spec.rb
+++ b/spec/lib/api_crawler_spec.rb
@@ -58,9 +58,11 @@ describe ApiCrawler do
   describe '#crawl' do
     context "and there is only one page" do
       let(:page_1_response){ build_response_with_body(total_pages:1, page: 1) }
+      let(:page_1_response_with_query_params){ build_response_with_body(total_pages:1, page: 1, items: ["query", "params"]) }
 
       before do
         stub_request(:get, "www.example.com").to_return page_1_response
+        stub_request(:get, "www.example.com?foo=bar&baz=2").to_return page_1_response_with_query_params
       end
 
       it "crawls the page writing the response to :output" do
@@ -76,17 +78,30 @@ describe ApiCrawler do
         benchmark_output.rewind
         expect(benchmark_output.read).to match(/^http:\/\/www.example.com took \d+.\d+ seconds$/)
       end
+
+      it "respects any passed in query params" do
+        crawler_options[:url] = "http://www.example.com?foo=bar&baz=2"
+        api_crawler.crawl
+        output.rewind
+        expect(output.read).to eq("#{page_1_response_with_query_params[:body]}\n")
+      end
     end
 
     context "and there are multiple pages" do
       let(:page_1_response){ build_response_with_body(page:1, total_pages:3) }
       let(:page_2_response){ build_response_with_body(page:2, total_pages:3) }
       let(:page_3_response){ build_response_with_body(page:3, total_pages:3) }
+      let(:page_1_response_with_query_params){ build_response_with_body(page: 1, total_pages:3, items: ["query", "params"]) }
+      let(:page_2_response_with_query_params){ build_response_with_body(page: 2, total_pages:3, items: ["query", "params"]) }
+      let(:page_3_response_with_query_params){ build_response_with_body(page: 3, total_pages:3, items: ["query", "params"]) }
 
       before do
         stub_request(:get, "www.example.com").to_return page_1_response
         stub_request(:get, "www.example.com").with(query: hash_including(page:'2')).to_return page_2_response
         stub_request(:get, "www.example.com").with(query: hash_including(page:'3')).to_return page_3_response
+        stub_request(:get, "www.example.com").with(query: {foo:'bar', baz:'1'}).to_return page_1_response_with_query_params
+        stub_request(:get, "www.example.com").with(query: hash_including(foo:'bar', baz:'1', page:'2')).to_return page_2_response_with_query_params
+        stub_request(:get, "www.example.com").with(query: hash_including(foo:'bar', baz:'1', page:'3')).to_return page_3_response_with_query_params
       end
 
       it "crawls all of the pages writing each response to its own line in :output" do
@@ -110,6 +125,22 @@ describe ApiCrawler do
         expect {
           api_crawler.crawl
         }.to change(api_crawler, :pages_left?).to(false)
+      end
+
+      it "respects any passed in query params and continues to pass them along in each request" do
+        crawler_options[:url] = "http://www.example.com/?baz=1&foo=bar"
+        api_crawler.crawl
+        output.rewind
+        expect(output.read).to eq([
+          page_1_response_with_query_params[:body],
+          page_2_response_with_query_params[:body],
+          page_3_response_with_query_params[:body]
+        ].join("\n") + "\n")
+      end
+    end
+
+    context "and the responses include newlines" do
+      it "removes the newlines when writing to :output" do
       end
     end
 


### PR DESCRIPTION
This PR applies to issue #343.

It ensures that the ApiCrawler maintains query parameters when crawling. This is so the sort order can be specified so that the API snapshots can be created by crawling the API in a predictable manner that won't result in duplicate entires due to records being created or updated while the snapshot is taking place.

Command I ran to verify after updating SERVERNAME in `.env` to be `localhost:3000`:

```
BENCHMARK=1 STOP_PAGE=2 PAGES_PER_JOB=1  be rake api:snapshot:all
```

Output from the benchmark files to show it's working:

```
==> tmp/snapshots/snapshot_2015-07-16/api_works.jsondump.benchmark <==
http://localhost:3000/api/works?sort=created_at took 12.422759 seconds
http://localhost:3000/api/works?page=2&sort=created_at took 32.370729 seconds

==> tmp/snapshots/snapshot_2015-07-16/api_events.jsondump.benchmark <==
http://localhost:3000/api/events?sort=created_at took 26.95926 seconds
http://localhost:3000/api/events?page=2&sort=created_at took 32.472512 seconds

==> tmp/snapshots/snapshot_2015-07-16/api_references.jsondump.benchmark <==
http://localhost:3000/api/references?sort=created_at took 43.090896 seconds
http://localhost:3000/api/references?page=2&sort=created_at took 20.002801 second

```