### PR TITLE
Fix api/events work lookup by id/PID

### DIFF
--- a/app/controllers/api/v6/events_controller.rb
+++ b/app/controllers/api/v6/events_controller.rb
@@ -24,7 +24,8 @@ class Api::V6::EventsController < Api::BaseController
   def index
     if params[:work_id]
       id_hash = get_id_hash(params[:work_id])
-      collection = RetrievalStatus.joins(:work).where("works.doi = ?", id_hash.fetch(:doi))
+      field = id_hash.keys.first
+      collection = RetrievalStatus.joins(:work).where("works.#{field} = ?", id_hash.fetch(field))
     elsif params[:work_ids]
       collection = RetrievalStatus.joins(:work).where("works.pid IN (?)", params[:work_ids])
     elsif params[:source_id]

--- a/app/controllers/api/v6/events_controller.rb
+++ b/app/controllers/api/v6/events_controller.rb
@@ -1,4 +1,7 @@
 class Api::V6::EventsController < Api::BaseController
+  # include helper module for DOI resolution
+  include Resolvable
+
   before_filter :authenticate_user_from_token!
 
   swagger_controller :events, "Events"
@@ -20,7 +23,8 @@ class Api::V6::EventsController < Api::BaseController
 
   def index
     if params[:work_id]
-      collection = RetrievalStatus.joins(:work).where("works.pid = ?", params[:work_id])
+      id_hash = get_id_hash(params[:work_id])
+      collection = RetrievalStatus.joins(:work).where("works.doi = ?", id_hash.fetch(:doi))
     elsif params[:work_ids]
       collection = RetrievalStatus.joins(:work).where("works.pid IN (?)", params[:work_ids])
     elsif params[:source_id]
@@ -47,4 +51,5 @@ class Api::V6::EventsController < Api::BaseController
 
     @events = collection.decorate
   end
+
 end

--- a/spec/apis/v6/events_spec.rb
+++ b/spec/apis/v6/events_spec.rb
@@ -95,6 +95,14 @@ describe "/api/v6/events", :type => :api do
         expect(item["by_month"]).not_to be_nil
         expect(item["by_year"]).not_to be_nil
       end
+
+      it "returns a valid JSON response with no events when provided with a bad id/pid" do
+        work.pid = "somebadpidvalue"
+        get uri, nil, headers
+        expect(last_response.status).to eq(200)
+        response = JSON.parse(last_response.body)
+        expect(response["meta"]["total"]).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
Fix failing api/v6/events_controller by sanitizing the work_id/PID using Resolvable#get_id_hash.

When the work_id(s) come thru as query parameters their double slashes in "http://" are preserved fine, but when they come thru as part of the URL path the double slashes get normalized to a single slash.

This makes sure that:
   http:/doi.org/10.1371/journal.pone.000001

which doesn't match anything becomes
   http://doi.org/10.1371/journal.pone.000001

which will make the right work and exhibit the expected behavior.