### PR TITLE
Issues/343 add date to snapshot filenames

### DIFF
--- a/app/models/data_exports/api_snapshot.rb
+++ b/app/models/data_exports/api_snapshot.rb
@@ -56,7 +56,7 @@ class ApiSnapshot < DataExport
   def snapshot_filepath
     @snapshot_filepath ||= begin
       snapshot_filename = uri.path.gsub(/^\/*/, '').gsub('/', '_')
-      "#{Pathname.new(snapshot_dir).join(snapshot_filename)}.#{filename_ext}"
+      "#{Pathname.new(snapshot_dir).join(snapshot_filename)}_#{snapshot_date}.#{filename_ext}"
     end
   end
 

--- a/app/models/data_exports/api_snapshot.rb
+++ b/app/models/data_exports/api_snapshot.rb
@@ -7,7 +7,7 @@ class ApiSnapshot < DataExport
 
   FILENAME_EXT = 'jsondump'
 
-  # +data_dir+ determines where all of the reports are written to.
+  # +snapshot_dir+ determines where all of the reports are written to.
   class_attribute :snapshot_dir
 
   self.snapshot_dir = Rails.root.join("tmp/snapshots")

--- a/spec/models/data_exports/api_snapshot_spec.rb
+++ b/spec/models/data_exports/api_snapshot_spec.rb
@@ -26,7 +26,7 @@ describe ApiSnapshot do
     it "affects the #snapshot_filepath" do
       attrs[:url] = "http://example.com/api/events"
       ApiSnapshot.snapshot_dir = Rails.root.join("foobarbaz")
-      expected_path = Rails.root.join("foobarbaz/snapshot_#{Time.zone.now.to_date}").join("api_events.jsondump")
+      expected_path = Rails.root.join("foobarbaz/snapshot_#{Time.zone.now.to_date}").join("api_events_#{Time.zone.now.to_date}.jsondump")
       expect(api_snapshot.snapshot_filepath).to eq(expected_path.to_s)
     end
   end
@@ -58,13 +58,13 @@ describe ApiSnapshot do
 
     it "has a snapshot_filepath based on the path portion of the given URL" do
       attrs[:url] = "http://example.com/api/works"
-      expected_path = ApiSnapshot.default_snapshot_dir.join("api_works.jsondump")
+      expected_path = ApiSnapshot.default_snapshot_dir.join("api_works_#{Time.zone.now.to_date}.jsondump")
       expect(api_snapshot.snapshot_filepath).to eq(expected_path.to_s)
     end
 
     it "has a zip_filepath representing where its zip file should exist; be named" do
       attrs[:url] = "http://example.com/api/events/foo/bar"
-      expected_path = ApiSnapshot.default_snapshot_dir.join("api_events_foo_bar.zip")
+      expected_path = ApiSnapshot.default_snapshot_dir.join("api_events_foo_bar_#{Time.zone.now.to_date}.zip")
       expect(api_snapshot.zip_filepath).to eq(expected_path.to_s)
     end
 
@@ -124,7 +124,7 @@ describe ApiSnapshot do
         expect(api_crawler_factory).to receive(:new) do |args|
           expect(args[:benchmark_output]).to be_kind_of(File)
 
-          expected_path = ApiSnapshot.default_snapshot_dir.join("foo_bars.jsondump.benchmark").to_s
+          expected_path = ApiSnapshot.default_snapshot_dir.join("foo_bars_#{Time.zone.now.to_date}.jsondump.benchmark").to_s
           expect(args[:benchmark_output].path).to eq(expected_path)
 
           api_crawler


### PR DESCRIPTION
Updating API snapshots to include the snapshot date in the JSON dump filename, benchmark filename, and zip filename.

E.g.:

* api_works_2015-07-16.jsondump
* api_works_2015-07-16.jsondump.benchmark
* api_works_2015-07-16.zip