### PR TITLE
Add /api/data_exports

### DIFF
--- a/app/controllers/api/v6/data_exports_controller.rb
+++ b/app/controllers/api/v6/data_exports_controller.rb
@@ -1,0 +1,26 @@
+class Api::V6::DataExportsController < Api::BaseController
+  before_filter :authenticate_user_from_token!
+
+  PER_PAGE = 1000
+
+  swagger_controller :data_exports, "DataExports"
+
+  swagger_api :index do
+    summary "Returns data exports in order of the most recent exports first"
+    # notes "If no work ids or source names are provided in the query, all events are returned, 1000 per page and sorted by update date."
+    param :query, :page, :integer, :optional, "Page number"
+    param :query, :per_page, :integer, :optional, "Results per page, defaults to 1000"
+    response :ok
+    response :unprocessable_entity
+    response :not_found
+    response :internal_server_error
+  end
+
+  def index
+    collection = DataExport.all.order("id DESC")
+    per_page = params[:per_page] && (0..PER_PAGE).include?(params[:per_page].to_i) ? params[:per_page].to_i : PER_PAGE
+    collection = collection.paginate(per_page: per_page, :page => params[:page])
+
+    @data_exports = collection.decorate
+  end
+end

--- a/app/decorators/data_export_decorator.rb
+++ b/app/decorators/data_export_decorator.rb
@@ -1,0 +1,7 @@
+class DataExportDecorator < Draper::Decorator
+  delegate_all
+
+  def self.collection_decorator_class
+    PaginatingDecorator
+  end
+end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -33,4 +33,16 @@ class DataExport < ActiveRecord::Base
   def previous_version
     @previous_version ||= self.class.find_previous_version_of(self)
   end
+
+  def state
+    if failed_at
+      "failed"
+    elsif finished_exporting_at
+      "done"
+    elsif started_exporting_at
+      "processing"
+    else
+      "pending"
+    end
+  end
 end

--- a/app/views/api/v6/data_exports/index.json.jbuilder
+++ b/app/views/api/v6/data_exports/index.json.jbuilder
@@ -1,0 +1,14 @@
+json.meta do
+  json.status "ok"
+  json.set! :"message-type", "data-exports-list"
+  json.set! :"message-version", "6.0.0"
+  json.total @data_exports.total_entries
+  json.total_pages @data_exports.per_page > 0 ? @data_exports.total_pages : 1
+  json.page @data_exports.total_entries > 0 ? @data_exports.current_page : 1
+end
+
+json.data_exports @data_exports do |data_export|
+  json.cache! ['v6', data_export], skip_digest: true do
+    json.(data_export, :url, :type, :started_exporting_at, :finished_exporting_at, :failed_at, :state)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Lagotto::Application.routes.draw do
 
       resources :alerts
       resources :api_requests, only: [:index]
+      resources :data_exports, only: [:index]
       resources :docs, only: [:index, :show]
       resources :events
       resources :groups, only: [:index, :show]

--- a/spec/apis/v6/data_exports_spec.rb
+++ b/spec/apis/v6/data_exports_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe "/api/v6/data_exports", :type => :api do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:headers) do
+    { "HTTP_ACCEPT" => "application/json; version=6",
+      "HTTP_AUTHORIZATION" => "Token token=#{user.api_key}" }
+  end
+  let(:jsonp_headers) do
+    { "HTTP_ACCEPT" => "application/javascript; version=6",
+      "HTTP_AUTHORIZATION" => "Token token=#{user.api_key}" }
+  end
+
+  context "index" do
+    def expect_items(items)
+      actual_item_order = items.map{ |export| export["state"] }
+      expected_item_order = data_exports.sort_by(&:id).reverse.map(&:state)
+      expect(actual_item_order).to eq(expected_item_order)
+
+      item = items.find{ |i| i["state"] == "done" }
+      expect(item["state"]).to eq(finished_data_export.state)
+      expect(item["url"]).to eq(finished_data_export.url)
+      expect(item["started_exporting_at"]).to_not be_nil
+      expect(item["finished_exporting_at"]).to_not be_nil
+
+      item = items.find{ |i| i["state"] == "failed" }
+      expect(item["failed_at"]).to_not be_nil
+
+      item = items.find{ |i| i["type"] == ZenodoDataExport.name }
+      expect(item).to_not be_nil
+    end
+
+    context "JSON" do
+      let!(:data_exports) { [failed_data_export, pending_data_export, started_data_export, finished_data_export, zenodo_data_export] }
+      let!(:failed_data_export){ FactoryGirl.create(:data_export, failed_at: Time.zone.now) }
+      let!(:pending_data_export){ FactoryGirl.create(:data_export, started_exporting_at:nil, finished_exporting_at: nil) }
+      let!(:started_data_export){ FactoryGirl.create(:data_export, started_exporting_at:Time.zone.now, finished_exporting_at:nil) }
+      let!(:finished_data_export){ FactoryGirl.create(:data_export, started_exporting_at:Time.zone.now, finished_exporting_at:Time.zone.now) }
+      let!(:zenodo_data_export){ FactoryGirl.create(:zenodo_data_export) }
+      let(:uri) { "/api/data_exports" }
+
+      it "JSON" do
+        get uri, nil, headers
+        expect(last_response.status).to eq(200)
+
+        response = JSON.parse(last_response.body)
+        expect(response["data_exports"].length).to eq(data_exports.length)
+
+        expect_items response["data_exports"]
+      end
+
+      it "JSONP" do
+        get "#{uri}?callback=_func", nil, jsonp_headers
+        expect(last_response.status).to eql(200)
+
+        # remove jsonp wrapper
+        response = JSON.parse(last_response.body[6...-1])
+        expect(response["data_exports"].length).to eq(data_exports.length)
+
+        expect_items response["data_exports"]
+      end
+    end
+  end
+end

--- a/spec/factories/default.rb
+++ b/spec/factories/default.rb
@@ -558,6 +558,7 @@ FactoryGirl.define do
 
   factory :data_export do
     sequence(:name){ |i| "Zenodo Export #{i}"}
+    sequence(:url){ |i| "http://example.com/#{i}"}
   end
 
   factory :api_snapshot, class: ApiSnapshot, parent: :data_export do

--- a/spec/models/data_export_spec.rb
+++ b/spec/models/data_export_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe DataExport do
+  subject(:data_export){ FactoryGirl.build(:data_export) }
 
   describe "#previous_version" do
     subject(:data_export){ FactoryGirl.create(:data_export, name: report_name) }
@@ -49,6 +50,27 @@ describe DataExport do
       it "returns nil" do
         expect(export_one_week_ago.previous_version).to be(nil)
       end
+    end
+  end
+
+  describe "#state" do
+    it "is 'pending' when not started, finished, or failed" do
+      expect(data_export.state).to eq("pending")
+    end
+
+    it "is 'processing' when started, but not finished or failed" do
+      data_export.started_exporting_at = Time.zone.now
+      expect(data_export.state).to eq("processing")
+    end
+
+    it "is 'done' when finished" do
+      data_export.finished_exporting_at = Time.zone.now
+      expect(data_export.state).to eq("done")
+    end
+
+    it "is 'failed' when failed"do
+      data_export.failed_at = Time.zone.now
+      expect(data_export.state).to eq("failed")
     end
 
   end


### PR DESCRIPTION
Adding "/api/data_exports" to return basic paginated list of data exort information sorted in descending order (newest first).

![screenshot 2015-07-16 14 53 34](https://cloud.githubusercontent.com/assets/967/8732288/7a3eb730-2bca-11e5-84fb-b2637c53a3cb.png)

If the export fails a `failed_at` timestamp will display as well.