### PR TITLE
ApiCrawler / ApiSnapshot'ing now supports end-points that don't page

### DIFF
--- a/lib/api_crawler.rb
+++ b/lib/api_crawler.rb
@@ -75,9 +75,15 @@ class ApiCrawler
     @output.puts response_body.gsub("\n", "")
     @num_pages_processed += 1
 
-    meta = json_data["meta"] || raise(MalformedResponseError, "Missing meta element in:\n #{response_body}")
-    @pageno = meta["page"] || raise(MalformedResponseError, "Missing page property in the meta element in:\n #{response_body}")
-    @total_pages = meta["total_pages"] || raise(MalformedResponseError, "Missing total_pages property in the meta element in:\n #{response_body}")
+    meta = json_data["meta"]
+    if meta && meta["page"] && meta["total_pages"]
+      @pageno = meta["page"]
+      @total_pages = meta["total_pages"]
+    else
+      # if we have a page of valid JSON w/o paging information
+      @total_pages ||= 1
+      @pageno = @total_pages
+    end
 
     if continue_crawling?
       next_uri = URI.parse(@url)

--- a/spec/lib/api_crawler_spec.rb
+++ b/spec/lib/api_crawler_spec.rb
@@ -229,36 +229,22 @@ describe ApiCrawler do
     end
 
     context "and an API page returns a malformed response body" do
-      it "raises an error when the response is missing the meta element" do
-        page_1_response = { status:200, body: {}.to_json }
-        stub_request(:get, "www.example.com").to_return page_1_response
-        expect{
-          api_crawler.crawl
-        }.to raise_error(ApiCrawler::MalformedResponseError, "Missing meta element in:\n #{page_1_response[:body]}")
-      end
-
-      it "raises an error when the response is missing the total_pages property" do
-        page_1_response = { status:200, body: {meta: {page: 1}}.to_json }
-        stub_request(:get, "www.example.com").to_return page_1_response
-        expect{
-          api_crawler.crawl
-        }.to raise_error(ApiCrawler::MalformedResponseError, "Missing total_pages property in the meta element in:\n #{page_1_response[:body]}")
-      end
-
-      it "raises an error when the response is missing the page property" do
-        page_1_response = { status:200, body: {meta: {total_pages: 1}}.to_json }
-        stub_request(:get, "www.example.com").to_return page_1_response
-        expect{
-          api_crawler.crawl
-        }.to raise_error(ApiCrawler::MalformedResponseError, "Missing page property in the meta element in:\n #{page_1_response[:body]}")
-      end
-
       it "raises an error when the response is not valid JSON" do
         page_1_response = { status:200, body: "This is not JSON." }
         stub_request(:get, "www.example.com").to_return page_1_response
         expect{
           api_crawler.crawl
         }.to raise_error(ApiCrawler::MalformedResponseError, "Response body was not valid JSON in:\n #{page_1_response[:body]}")
+      end
+    end
+
+    context "and an API page doesn't supply meta information (e.g. no pagination)" do
+      it "crawls the page writing the response to :output" do
+        page_1_response = { status:200, body: {}.to_json }
+        stub_request(:get, "www.example.com").to_return page_1_response
+        api_crawler.crawl
+        output.rewind
+        expect(output.read).to eq("#{page_1_response[:body]}\n")
       end
     end
 


### PR DESCRIPTION
The ApiCrawler can no crawl a JSON response that doesn't include pagi…ng information.

It will consider it the last and final page to crawl for a given endpoint. This will most likely always be page 1 of 1.